### PR TITLE
Introduce ldap custom attributes filtering and whitelisting

### DIFF
--- a/src/main/java/com/floragunn/dlic/auth/ldap/LdapUser.java
+++ b/src/main/java/com/floragunn/dlic/auth/ldap/LdapUser.java
@@ -14,11 +14,13 @@
 
 package com.floragunn.dlic.auth.ldap;
 
+import java.util.List;
 import java.util.Map;
 
 import org.ldaptive.LdapAttribute;
 import org.ldaptive.LdapEntry;
 
+import com.floragunn.searchguard.support.WildcardMatcher;
 import com.floragunn.searchguard.user.AuthCredentials;
 import com.floragunn.searchguard.user.User;
 
@@ -28,7 +30,7 @@ public class LdapUser extends User {
     private final LdapEntry userEntry;
     private final String originalUsername;
 
-    public LdapUser(final String name, String originalUsername, final LdapEntry userEntry, final AuthCredentials credentials) {
+    public LdapUser(final String name, String originalUsername, final LdapEntry userEntry, final AuthCredentials credentials, int customAttrMaxValueLen, List<String> whiteListedAttributes) {
         super(name, null, credentials);
         this.originalUsername = originalUsername;
         this.userEntry = userEntry;
@@ -36,8 +38,22 @@ public class LdapUser extends User {
         attributes.put("ldap.original.username", originalUsername);
         attributes.put("ldap.dn", userEntry.getDn());
         
-        for(LdapAttribute attr: userEntry.getAttributes()) {
-            attributes.put("attr.ldap."+attr.getName(), attr.getStringValue());
+        if(customAttrMaxValueLen > 0) {
+            for(LdapAttribute attr: userEntry.getAttributes()) {
+                if(attr != null && !attr.isBinary() && !attr.getName().toLowerCase().contains("password")) {
+                    final String val = attr.getStringValue();
+                    //only consider attributes which are not binary and where its value is not longer than customAttrMaxValueLen characters
+                    if(val != null && val.length() > 0 && val.length() <= customAttrMaxValueLen) {
+                        if(whiteListedAttributes != null && !whiteListedAttributes.isEmpty()) {
+                            if(WildcardMatcher.matchAny(whiteListedAttributes, attr.getName())) {
+                                attributes.put("attr.ldap."+attr.getName(), val);
+                            }
+                        } else {
+                            attributes.put("attr.ldap."+attr.getName(), val);
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/src/main/java/com/floragunn/dlic/auth/ldap/backend/LDAPAuthenticationBackend.java
+++ b/src/main/java/com/floragunn/dlic/auth/ldap/backend/LDAPAuthenticationBackend.java
@@ -124,8 +124,13 @@ public class LDAPAuthenticationBackend implements AuthenticationBackend {
             if(log.isDebugEnabled()) {
                 log.debug("Authenticated username {}", username);
             }
+            
+            final int customAttrMaxValueLen = settings.getAsInt(ConfigConstants.LDAP_CUSTOM_ATTR_MAXVAL_LEN, 36);
+            final List<String> whitelistedAttributes = settings.getAsList(ConfigConstants.LDAP_CUSTOM_ATTR_WHITELIST, null);
 
-            return new LdapUser(username, user, entry, credentials);
+            //by default all ldap attributes which are not binary and with a max value length of 36 are included in the user object
+            //if the whitelist contains at least one value then all attributes will be additional check if whitelisted (whitelist can contain wildcard and regex)
+            return new LdapUser(username, user, entry, credentials, customAttrMaxValueLen, whitelistedAttributes);
 
         } catch (final Exception e) {
             if(log.isDebugEnabled()) {

--- a/src/main/java/com/floragunn/dlic/auth/ldap/backend/LDAPAuthorizationBackend.java
+++ b/src/main/java/com/floragunn/dlic/auth/ldap/backend/LDAPAuthorizationBackend.java
@@ -489,10 +489,11 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
                 log.trace("roles count total {}", roles.size());
             }
             
-            final List<String> nestedRoleFilter = settings.getAsList(ConfigConstants.LDAP_AUTHZ_NESTEDROLEFILTER, Collections.emptyList());
 
             // nested roles
             if (settings.getAsBoolean(ConfigConstants.LDAP_AUTHZ_RESOLVE_NESTED_ROLES, false)) {
+                
+                final List<String> nestedRoleFilter = settings.getAsList(ConfigConstants.LDAP_AUTHZ_NESTEDROLEFILTER, Collections.emptyList());
 
                 if(log.isTraceEnabled()) {
                     log.trace("Evaluate nested roles");

--- a/src/main/java/com/floragunn/dlic/auth/ldap/util/ConfigConstants.java
+++ b/src/main/java/com/floragunn/dlic/auth/ldap/util/ConfigConstants.java
@@ -59,10 +59,12 @@ public final class ConfigConstants {
     public static final String LDAPS_PEMTRUSTEDCAS_FILEPATH = "pemtrustedcas_filepath";
     public static final String LDAPS_PEMTRUSTEDCAS_CONTENT = "pemtrustedcas_content";
 
-    
-    
     public static final String LDAPS_ENABLED_SSL_CIPHERS = "enabled_ssl_ciphers";
     public static final String LDAPS_ENABLED_SSL_PROTOCOLS = "enabled_ssl_protocols";
+    
+    //custom attributes
+    public static final String LDAP_CUSTOM_ATTR_MAXVAL_LEN = "custom_attrmaxval_len";
+    public static final String LDAP_CUSTOM_ATTR_WHITELIST = "custom_attr_whitelist";
 
     private ConfigConstants() {
 

--- a/src/main/java/com/floragunn/dlic/auth/ldap/util/ConfigConstants.java
+++ b/src/main/java/com/floragunn/dlic/auth/ldap/util/ConfigConstants.java
@@ -63,7 +63,7 @@ public final class ConfigConstants {
     public static final String LDAPS_ENABLED_SSL_PROTOCOLS = "enabled_ssl_protocols";
     
     //custom attributes
-    public static final String LDAP_CUSTOM_ATTR_MAXVAL_LEN = "custom_attrmaxval_len";
+    public static final String LDAP_CUSTOM_ATTR_MAXVAL_LEN = "custom_attr_maxval_len";
     public static final String LDAP_CUSTOM_ATTR_WHITELIST = "custom_attr_whitelist";
 
     private ConfigConstants() {

--- a/src/test/java/com/floragunn/dlic/auth/ldap/LdapBackendTest.java
+++ b/src/test/java/com/floragunn/dlic/auth/ldap/LdapBackendTest.java
@@ -788,6 +788,46 @@ public class LdapBackendTest {
         Assert.assertEquals("rolemo4", new ArrayList(new TreeSet(user.getRoles())).get(2));
     }
     
+    @Test
+    public void testCustomAttributes() throws Exception {
+
+        startLDAPServer();
+
+        Settings settings = Settings.builder()
+                .putList(ConfigConstants.LDAP_HOSTS, "127.0.0.1:4", "localhost:" + EmbeddedLDAPServer.ldapPort)
+                .put(ConfigConstants.LDAP_AUTHC_USERSEARCH, "(uid={0})").build();
+
+        LdapUser user = (LdapUser) new LDAPAuthenticationBackend(settings, null).authenticate(new AuthCredentials("jacksonm", "secret"
+                .getBytes(StandardCharsets.UTF_8)));
+        Assert.assertNotNull(user);
+        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        Assert.assertEquals(user.getCustomAttributesMap().toString(), 13, user.getCustomAttributesMap().size());
+        Assert.assertFalse(user.getCustomAttributesMap().toString(), user.getCustomAttributesMap().keySet().contains("attr.ldap.userpassword"));
+    
+        settings = Settings.builder()
+                .putList(ConfigConstants.LDAP_HOSTS, "127.0.0.1:4", "localhost:" + EmbeddedLDAPServer.ldapPort)
+                .put(ConfigConstants.LDAP_AUTHC_USERSEARCH, "(uid={0})")
+                .put(ConfigConstants.LDAP_CUSTOM_ATTR_MAXVAL_LEN, 0)
+                .build();
+
+        user = (LdapUser) new LDAPAuthenticationBackend(settings, null).authenticate(new AuthCredentials("jacksonm", "secret"
+                .getBytes(StandardCharsets.UTF_8)));
+    
+        Assert.assertEquals(user.getCustomAttributesMap().toString(), 2, user.getCustomAttributesMap().size());
+        
+        settings = Settings.builder()
+                .putList(ConfigConstants.LDAP_HOSTS, "127.0.0.1:4", "localhost:" + EmbeddedLDAPServer.ldapPort)
+                .put(ConfigConstants.LDAP_AUTHC_USERSEARCH, "(uid={0})")
+                .putList(ConfigConstants.LDAP_CUSTOM_ATTR_WHITELIST, "*objectclass*","entryParentId")
+                .build();
+
+        user = (LdapUser) new LDAPAuthenticationBackend(settings, null).authenticate(new AuthCredentials("jacksonm", "secret"
+                .getBytes(StandardCharsets.UTF_8)));
+    
+        Assert.assertEquals(user.getCustomAttributesMap().toString(), 4, user.getCustomAttributesMap().size());
+    
+    }
+    
     @After
     public void tearDown() throws Exception {
 

--- a/src/test/resources/ldap/base.ldif
+++ b/src/test/resources/ldap/base.ldif
@@ -47,6 +47,8 @@ uid: jacksonm
 userpassword: secret
 mail: jacksonm@example.com
 ou: Human Resources
+userPKCS12::YWJjdmdmcnQ=YWJjdmdmcnQ=YWJjdmdmcnQ=YWJjdmdmcnQ=YWJjdmdmcnQ=
+userSMIMECertificate;binary: abc
 
 dn: cn=Captain Spock,ou=people,o=TEST
 objectclass: inetOrgPerson


### PR DESCRIPTION
By default all ldap attributes which are not binary and with a max value length of 36 are included in the user object (should keep backwards compat)

If the whitelist contains at least one value then all attributes will be additional check if whitelisted (whitelist can contain wildcard and regex). Config prop is custom_attr_whitelist

Disable attributes by setting custom_attr_maxval_len to 0