### PR TITLE
ITT-1570 remove password hash from REST API

### DIFF
--- a/src/main/java/com/floragunn/searchguard/dlic/rest/api/AbstractApiAction.java
+++ b/src/main/java/com/floragunn/searchguard/dlic/rest/api/AbstractApiAction.java
@@ -206,14 +206,21 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 
 		final String resourcename = request.param("name");
 
-		final Settings configurationSettings = loadAsSettings(getConfigName(), true);
+		final Settings.Builder settingsBuilder = load(getConfigName(), true);
+
+		// filter hidden resources and sensitive settings
+		filter(settingsBuilder);
+		
+		final Settings configurationSettings = settingsBuilder.build();
 
 		// no specific resource requested, return complete config
 		if (resourcename == null || resourcename.length() == 0) {
 			return new Tuple<String[], RestResponse>(new String[0],
 					new BytesRestResponse(RestStatus.OK, convertToJson(configurationSettings)));
 		}
-
+		
+		
+		
 		final Map<String, Object> con = 
 		        new HashMap<>(Utils.convertJsonToxToStructuredMap(Settings.builder().put(configurationSettings).build()))
 		        .entrySet()
@@ -242,6 +249,10 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 			return false;
 		}
 		return true;
+	}
+	
+	protected void filter(Settings.Builder builder) {
+	    // subclasses can implement resource filtering
 	}
 	
 	protected void save(final Client client, final RestRequest request, final String config,

--- a/src/main/java/com/floragunn/searchguard/dlic/rest/api/InternalUsersApiAction.java
+++ b/src/main/java/com/floragunn/searchguard/dlic/rest/api/InternalUsersApiAction.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.bouncycastle.crypto.generators.OpenBSDBCrypt;
@@ -136,7 +137,19 @@ public class InternalUsersApiAction extends AbstractApiAction {
 		}
 
 	}
-
+	
+	@Override
+	protected void filter(Settings.Builder builder) {
+	    super.filter(builder);
+	    // replace password hashes in addition. We must not remove them from the
+	    // Builder since this would remove users completely if they
+	    // do not have any addition properties like roles or attributes
+	    Set<String> entries = builder.build().getAsGroups().keySet();
+	    for (String key : entries) {
+            builder.put(key + ".hash", "");
+        }	    
+	}
+	
 	public static String hash(final char[] clearTextPassword) {
 	    final byte[] salt = new byte[16];
         new SecureRandom().nextBytes(salt);

--- a/src/test/java/com/floragunn/searchguard/dlic/rest/api/GetConfigurationApiTest.java
+++ b/src/test/java/com/floragunn/searchguard/dlic/rest/api/GetConfigurationApiTest.java
@@ -48,8 +48,8 @@ public class GetConfigurationApiTest extends AbstractRestApiUnitTest {
 		response = rh.executeGetRequest("_searchguard/api/configuration/internalusers");
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 		settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-		Assert.assertEquals(settings.get("admin.hash"), "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG");
-		Assert.assertEquals(settings.get("other.hash"), "someotherhash");
+		Assert.assertEquals("", settings.get("admin.hash"));
+		Assert.assertEquals("", settings.get("other.hash"));
 
 		// roles
 		response = rh.executeGetRequest("_searchguard/api/configuration/roles");

--- a/src/test/java/com/floragunn/searchguard/dlic/rest/api/RoleBasedAccessTest.java
+++ b/src/test/java/com/floragunn/searchguard/dlic/rest/api/RoleBasedAccessTest.java
@@ -43,7 +43,7 @@ public class RoleBasedAccessTest extends AbstractRestApiUnitTest {
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 		Settings settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
 		Assert.assertTrue(settings.get("admin.hash") != null);
-		Assert.assertEquals(settings.get("admin.hash"), "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG");
+		Assert.assertEquals("", settings.get("admin.hash"));
 		
 		// new user API, accessible for worf, single user
 		response = rh.executeGetRequest("/_searchguard/api/user/admin", encodeBasicHeader("worf", "worf"));
@@ -55,59 +55,59 @@ public class RoleBasedAccessTest extends AbstractRestApiUnitTest {
 		response = rh.executeGetRequest("/_searchguard/api/user/", encodeBasicHeader("worf", "worf"));
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 		settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-		Assert.assertEquals(settings.get("admin.hash"), "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG");
-		Assert.assertEquals(settings.get("sarek.hash"), "$2a$12$Ioo1uXmH.Nq/lS5dUVBEsePSmZ5pSIpVO/xKHaquU/Jvq97I7nAgG");
-		Assert.assertEquals(settings.get("worf.hash"), "$2a$12$A41IxPXV1/Dx46C6i1ufGubv.p3qYX7xVcY46q33sylYbIqQVwTMu");
+		Assert.assertEquals("", settings.get("admin.hash"));
+		Assert.assertEquals("", settings.get("sarek.hash"));
+		Assert.assertEquals("", settings.get("worf.hash"));
 		
 		// new user API, accessible for worf
 		response = rh.executeGetRequest("/_searchguard/api/internalusers/", encodeBasicHeader("worf", "worf"));
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 		settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-		Assert.assertEquals(settings.get("admin.hash"), "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG");
-		Assert.assertEquals(settings.get("sarek.hash"), "$2a$12$Ioo1uXmH.Nq/lS5dUVBEsePSmZ5pSIpVO/xKHaquU/Jvq97I7nAgG");
-		Assert.assertEquals(settings.get("worf.hash"), "$2a$12$A41IxPXV1/Dx46C6i1ufGubv.p3qYX7xVcY46q33sylYbIqQVwTMu");
+		Assert.assertEquals("", settings.get("admin.hash"));
+		Assert.assertEquals("", settings.get("sarek.hash"));
+		Assert.assertEquals("", settings.get("worf.hash"));
 
 		// legacy user API, accessible for worf, get complete config, no trailing slash
 		response = rh.executeGetRequest("/_searchguard/api/user", encodeBasicHeader("worf", "worf"));
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 		settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-		Assert.assertEquals(settings.get("admin.hash"), "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG");
-		Assert.assertEquals(settings.get("sarek.hash"), "$2a$12$Ioo1uXmH.Nq/lS5dUVBEsePSmZ5pSIpVO/xKHaquU/Jvq97I7nAgG");
-		Assert.assertEquals(settings.get("worf.hash"), "$2a$12$A41IxPXV1/Dx46C6i1ufGubv.p3qYX7xVcY46q33sylYbIqQVwTMu");
+		Assert.assertEquals("", settings.get("admin.hash"));
+		Assert.assertEquals("", settings.get("sarek.hash"));
+		Assert.assertEquals("", settings.get("worf.hash"));
 
 		// new user API, accessible for worf, get complete config, no trailing slash
 		response = rh.executeGetRequest("/_searchguard/api/internalusers", encodeBasicHeader("worf", "worf"));
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 		settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-		Assert.assertEquals(settings.get("admin.hash"), "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG");
-		Assert.assertEquals(settings.get("sarek.hash"), "$2a$12$Ioo1uXmH.Nq/lS5dUVBEsePSmZ5pSIpVO/xKHaquU/Jvq97I7nAgG");
-		Assert.assertEquals(settings.get("worf.hash"), "$2a$12$A41IxPXV1/Dx46C6i1ufGubv.p3qYX7xVcY46q33sylYbIqQVwTMu");
+		Assert.assertEquals("", settings.get("admin.hash"));
+		Assert.assertEquals("", settings.get("sarek.hash"));
+		Assert.assertEquals("", settings.get("worf.hash"));
 
 		// roles API, GET accessible for worf
 		response = rh.executeGetRequest("/_searchguard/api/rolesmapping", encodeBasicHeader("worf", "worf"));
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 		settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-		Assert.assertEquals(settings.getAsList("sg_all_access.users").get(0), "nagilum");
-		Assert.assertEquals(settings.getAsList("sg_role_starfleet_library.backendroles").get(0), "starfleet*");
-		Assert.assertEquals(settings.getAsList("sg_zdummy_all.users").get(0), "bug108");
+		Assert.assertEquals("", settings.getAsList("sg_all_access.users").get(0), "nagilum");
+		Assert.assertEquals("", settings.getAsList("sg_role_starfleet_library.backendroles").get(0), "starfleet*");
+		Assert.assertEquals("", settings.getAsList("sg_zdummy_all.users").get(0), "bug108");
 		
 		
 		// Deprecated get configuration API, acessible for sarek
 		response = rh.executeGetRequest("_searchguard/api/configuration/internalusers", encodeBasicHeader("sarek", "sarek"));
 		settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-		Assert.assertEquals(settings.get("admin.hash"), "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG");
-		Assert.assertEquals(settings.get("sarek.hash"), "$2a$12$Ioo1uXmH.Nq/lS5dUVBEsePSmZ5pSIpVO/xKHaquU/Jvq97I7nAgG");
-		Assert.assertEquals(settings.get("worf.hash"), "$2a$12$A41IxPXV1/Dx46C6i1ufGubv.p3qYX7xVcY46q33sylYbIqQVwTMu");
+		Assert.assertEquals("", settings.get("admin.hash"));
+		Assert.assertEquals("", settings.get("sarek.hash"));
+		Assert.assertEquals("", settings.get("worf.hash"));
 
 		// Deprecated get configuration API, acessible for sarek
 		response = rh.executeGetRequest("_searchguard/api/configuration/actiongroups", encodeBasicHeader("sarek", "sarek"));
 		settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-		Assert.assertEquals(settings.getAsList("ALL").get(0), "indices:*");
-		Assert.assertEquals(settings.getAsList("CLUSTER_MONITOR").get(0), "cluster:monitor/*");
+		Assert.assertEquals("", settings.getAsList("ALL").get(0), "indices:*");
+		Assert.assertEquals("", settings.getAsList("CLUSTER_MONITOR").get(0), "cluster:monitor/*");
 		// new format for action groups
-		Assert.assertEquals(settings.getAsList("CRUD.permissions").get(0), "READ");
+		Assert.assertEquals("", settings.getAsList("CRUD.permissions").get(0), "READ");
 		
 		// --- Forbidden ---
 				
@@ -219,7 +219,7 @@ public class RoleBasedAccessTest extends AbstractRestApiUnitTest {
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 		settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
 		Assert.assertTrue(settings.get("admin.hash") != null);
-		Assert.assertEquals(settings.get("admin.hash"), "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG");
+		Assert.assertEquals("", settings.get("admin.hash"));
 		
 		// worf and config
 		response = rh.executeGetRequest("_searchguard/api/configuration/actiongroups", encodeBasicHeader("bla", "fasel"));

--- a/src/test/java/com/floragunn/searchguard/dlic/rest/api/UserApiTest.java
+++ b/src/test/java/com/floragunn/searchguard/dlic/rest/api/UserApiTest.java
@@ -53,8 +53,8 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 		Assert.assertEquals(response.getBody(), HttpStatus.SC_OK, response.getStatusCode());
 		settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
 		Assert.assertEquals(1, settings.size());
-		Assert.assertEquals("$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG",
-				settings.get("admin.hash"));
+		// hash must be filtered
+		Assert.assertEquals("", settings.get("admin.hash"));
 
 		// GET, user does not exist
 		response = rh.executeGetRequest("/_searchguard/api/user/nothinghthere", new Header[0]);
@@ -163,7 +163,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 		response = rh.executeGetRequest("/_searchguard/api/user/nagilum", new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 		settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-		Assert.assertTrue(settings.get("nagilum.hash").equals("$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m"));
+		Assert.assertTrue(settings.get("nagilum.hash").equals(""));
 
 		
 		// ROLES
@@ -230,7 +230,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 		response = rh.executeGetRequest("/_searchguard/api/user/picard", new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 		settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-		Assert.assertNotEquals(null, Strings.emptyToNull(settings.get("picard.hash")));
+		Assert.assertEquals("", settings.get("picard.hash"));
 		List<String> roles = settings.getAsList("picard.roles");
 		Assert.assertNotNull(roles);
 		Assert.assertEquals(2, roles.size());


### PR DESCRIPTION
This PR removes the password hash from the internal users and the configuration REST API. It also prepares for hiding resources in the REST API.