### PR TITLE
Feature/rest patch

### DIFF
--- a/src/main/java/com/floragunn/searchguard/dlic/rest/api/AbstractApiAction.java
+++ b/src/main/java/com/floragunn/searchguard/dlic/rest/api/AbstractApiAction.java
@@ -238,7 +238,6 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 				new BytesRestResponse(RestStatus.OK, XContentHelper.convertToJson(Utils.convertStructuredMapToBytes(con), false, false, XContentType.JSON)));
 	}
 
-
 	protected final Settings.Builder load(final String config, boolean triggerComplianceWhenCached) {
 		return Settings.builder().put(loadAsSettings(config, triggerComplianceWhenCached));
 	}

--- a/src/main/java/com/floragunn/searchguard/dlic/rest/api/ActionGroupsApiAction.java
+++ b/src/main/java/com/floragunn/searchguard/dlic/rest/api/ActionGroupsApiAction.java
@@ -35,7 +35,7 @@ import com.floragunn.searchguard.dlic.rest.validation.ActionGroupValidator;
 import com.floragunn.searchguard.ssl.transport.PrincipalExtractor;
 import com.floragunn.searchguard.support.ConfigConstants;
 
-public class ActionGroupsApiAction extends AbstractApiAction {
+public class ActionGroupsApiAction extends PatchableResourceApiAction {
 
 	@Inject
 	public ActionGroupsApiAction(final Settings settings, final Path configPath, final RestController controller, final Client client,
@@ -55,6 +55,7 @@ public class ActionGroupsApiAction extends AbstractApiAction {
 		controller.registerHandler(Method.GET, "/_searchguard/api/actiongroups/", this);
 		controller.registerHandler(Method.DELETE, "/_searchguard/api/actiongroups/{name}", this);
 		controller.registerHandler(Method.PUT, "/_searchguard/api/actiongroups/{name}", this);
+        controller.registerHandler(Method.PATCH, "/_searchguard/api/actiongroups/{name}", this);
 
 	}
 	

--- a/src/main/java/com/floragunn/searchguard/dlic/rest/api/PatchableResourceApiAction.java
+++ b/src/main/java/com/floragunn/searchguard/dlic/rest/api/PatchableResourceApiAction.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2016-2018 by floragunn GmbH - All rights reserved
+ * 
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed here is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 
+ * This software is free of charge for non-commercial and academic use. 
+ * For commercial use in a production environment you have to obtain a license 
+ * from https://floragunn.com
+ * 
+ */
+
+package com.floragunn.searchguard.dlic.rest.api;
+
+import java.nio.file.Path;
+
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.rest.BytesRestResponse;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestRequest.Method;
+import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.flipkart.zjsonpatch.JsonPatch;
+import com.flipkart.zjsonpatch.JsonPatchApplicationException;
+import com.floragunn.searchguard.auditlog.AuditLog;
+import com.floragunn.searchguard.configuration.AdminDNs;
+import com.floragunn.searchguard.configuration.IndexBaseConfigurationRepository;
+import com.floragunn.searchguard.configuration.PrivilegesEvaluator;
+import com.floragunn.searchguard.dlic.rest.support.Utils;
+import com.floragunn.searchguard.dlic.rest.validation.AbstractConfigurationValidator;
+import com.floragunn.searchguard.ssl.transport.PrincipalExtractor;
+
+public abstract class PatchableResourceApiAction extends AbstractApiAction {
+
+    public PatchableResourceApiAction(Settings settings, Path configPath, RestController controller, Client client,
+            AdminDNs adminDNs, IndexBaseConfigurationRepository cl, ClusterService cs,
+            PrincipalExtractor principalExtractor, PrivilegesEvaluator evaluator, ThreadPool threadPool,
+            AuditLog auditLog) {
+        super(settings, configPath, controller, client, adminDNs, cl, cs, principalExtractor, evaluator, threadPool,
+                auditLog);
+    }
+
+    protected Tuple<String[], RestResponse> handlePatch(final RestRequest request, final Client client)
+            throws Throwable {
+        if (request.getXContentType() != XContentType.JSON) {
+            return badRequestResponse("PATCH accepts only application/json");
+        }
+
+        String name = request.param("name");
+
+        if (name == null || name.length() == 0) {
+            return badRequestResponse("No " + getResourceName() + " specified");
+        }
+
+        Settings existingAsSettings = loadAsSettings(getConfigName(), false);
+
+        if (isHidden(existingAsSettings, name)) {
+            return notFound(getResourceName() + " " + name + " not found.");
+        }
+
+        if (isReadOnly(existingAsSettings, name)) {
+            return forbidden("Resource '" + name + "' is read-only.");
+        }
+
+        Settings resourceSettings = existingAsSettings.getAsSettings(name);
+
+        if (resourceSettings.isEmpty()) {
+            return notFound(getResourceName() + " " + name + " not found.");
+        }
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonPatch = objectMapper.readTree(request.content().utf8ToString());
+        JsonNode existingAsJsonNode = Utils.convertJsonToJackson(existingAsSettings);
+
+        if (!(existingAsJsonNode instanceof ObjectNode)) {
+            return internalErrorResponse("Config " + getConfigName() + " is malformed");
+        }
+
+        ObjectNode existingAsObjectNode = (ObjectNode) existingAsJsonNode;
+
+        JsonNode existingResourceAsJsonNode = existingAsJsonNode.get(name);
+
+        JsonNode patchedResourceAsJsonNode;
+
+        try {
+            patchedResourceAsJsonNode = applyPatch(jsonPatch, existingResourceAsJsonNode);
+        } catch (JsonPatchApplicationException e) {
+            return badRequestResponse(e.getMessage());
+        }
+        
+        BytesReference patchedResourceAsByteReference = new BytesArray(
+                objectMapper.writeValueAsString(patchedResourceAsJsonNode).getBytes());
+        
+        AbstractConfigurationValidator validator = getValidator(request.method(), patchedResourceAsByteReference);
+
+        if (!validator.validateSettings()) {
+            request.params().clear();
+            return new Tuple<String[], RestResponse>(new String[0],
+                    new BytesRestResponse(RestStatus.BAD_REQUEST, validator.errorsAsXContent()));
+        }        
+        
+        JsonNode updatedAsJsonNode = existingAsObjectNode.deepCopy().set(name, patchedResourceAsJsonNode);
+
+        BytesReference updatedAsBytesReference = new BytesArray(
+                objectMapper.writeValueAsString(updatedAsJsonNode).getBytes());
+
+        save(client, request, getConfigName(), updatedAsBytesReference);
+
+        return successResponse("'" + name + "' updated.", getConfigName());
+
+    }
+
+    protected JsonNode applyPatch(JsonNode jsonPatch, JsonNode existingResourceAsJsonNode) {
+        return JsonPatch.apply(jsonPatch, existingResourceAsJsonNode);
+    }
+
+    protected Tuple<String[], RestResponse> handleApiRequest(final RestRequest request, final Client client)
+            throws Throwable {
+
+        if (request.method() == Method.PATCH) {
+            return handlePatch(request, client);
+        } else {
+            return super.handleApiRequest(request, client);
+        }
+    }
+
+}

--- a/src/main/java/com/floragunn/searchguard/dlic/rest/api/RolesApiAction.java
+++ b/src/main/java/com/floragunn/searchguard/dlic/rest/api/RolesApiAction.java
@@ -34,7 +34,7 @@ import com.floragunn.searchguard.dlic.rest.validation.RolesValidator;
 import com.floragunn.searchguard.ssl.transport.PrincipalExtractor;
 import com.floragunn.searchguard.support.ConfigConstants;
 
-public class RolesApiAction extends AbstractApiAction {
+public class RolesApiAction extends PatchableResourceApiAction {
 
 	@Inject
 	public RolesApiAction(Settings settings, final Path configPath, RestController controller, Client client, AdminDNs adminDNs, IndexBaseConfigurationRepository cl,
@@ -44,6 +44,8 @@ public class RolesApiAction extends AbstractApiAction {
 		controller.registerHandler(Method.GET, "/_searchguard/api/roles/{name}", this);
 		controller.registerHandler(Method.DELETE, "/_searchguard/api/roles/{name}", this);
 		controller.registerHandler(Method.PUT, "/_searchguard/api/roles/{name}", this);
+        controller.registerHandler(Method.PATCH, "/_searchguard/api/roles/{name}", this);
+		
 	}
 
 	@Override

--- a/src/main/java/com/floragunn/searchguard/dlic/rest/api/RolesMappingApiAction.java
+++ b/src/main/java/com/floragunn/searchguard/dlic/rest/api/RolesMappingApiAction.java
@@ -34,7 +34,7 @@ import com.floragunn.searchguard.dlic.rest.validation.RolesMappingValidator;
 import com.floragunn.searchguard.ssl.transport.PrincipalExtractor;
 import com.floragunn.searchguard.support.ConfigConstants;
 
-public class RolesMappingApiAction extends AbstractApiAction {
+public class RolesMappingApiAction extends PatchableResourceApiAction {
 
 	@Inject
 	public RolesMappingApiAction(final Settings settings, final Path configPath, final RestController controller, final Client client,
@@ -46,6 +46,7 @@ public class RolesMappingApiAction extends AbstractApiAction {
 		controller.registerHandler(Method.GET, "/_searchguard/api/rolesmapping/{name}", this);
 		controller.registerHandler(Method.DELETE, "/_searchguard/api/rolesmapping/{name}", this);
 		controller.registerHandler(Method.PUT, "/_searchguard/api/rolesmapping/{name}", this);
+        controller.registerHandler(Method.PATCH, "/_searchguard/api/rolesmapping/{name}", this);
 
 	}
 

--- a/src/main/java/com/floragunn/searchguard/dlic/rest/support/Utils.java
+++ b/src/main/java/com/floragunn/searchguard/dlic/rest/support/Utils.java
@@ -27,6 +27,8 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.floragunn.searchguard.support.SearchGuardDeprecationHandler;
 
 public class Utils {
@@ -65,6 +67,16 @@ public class Utils {
         } catch (IOException e) {
             throw new ElasticsearchParseException("Failed to convert map", e);
         }
+    }
+    
+    public static JsonNode convertJsonToJackson(ToXContent jsonContent) {
+        try {
+            final BytesReference bytes = XContentHelper.toXContent(jsonContent, XContentType.JSON, false);
+            return new ObjectMapper().readTree(bytes.utf8ToString());
+        } catch (IOException e1) {
+            throw ExceptionsHelper.convertToElastic(e1);
+        }
+        
     }
     
 }

--- a/src/test/java/com/floragunn/searchguard/dlic/rest/api/ActionGroupsApiTest.java
+++ b/src/test/java/com/floragunn/searchguard/dlic/rest/api/ActionGroupsApiTest.java
@@ -162,6 +162,22 @@ public class ActionGroupsApiTest extends AbstractRestApiUnitTest {
 		response = rh.executePutRequest("/_searchguard/api/actiongroup/GET", FileHelper.loadFile("restapi/actiongroup_read.json"), new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
 		Assert.assertTrue(response.getBody().contains("Resource 'GET' is read-only."));
+		
+		// -- GET hidden resource, must be 404
+        rh.sendHTTPClientCertificate = true;
+        response = rh.executeGetRequest("/_searchguard/api/actiongroup/INTERNAL", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());		
+		
+		// -- DELETE hidden resource, must be 404
+        rh.sendHTTPClientCertificate = true;
+        response = rh.executeDeleteRequest("/_searchguard/api/actiongroup/INTERNAL", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+
+        // -- PUT hidden resource, must be forbidden
+        rh.sendHTTPClientCertificate = true;
+        response = rh.executePutRequest("/_searchguard/api/actiongroup/INTERNAL", FileHelper.loadFile("restapi/actiongroup_read.json"), new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        
 
 	}
 }

--- a/src/test/java/com/floragunn/searchguard/dlic/rest/api/GetConfigurationApiTest.java
+++ b/src/test/java/com/floragunn/searchguard/dlic/rest/api/GetConfigurationApiTest.java
@@ -68,6 +68,7 @@ public class GetConfigurationApiTest extends AbstractRestApiUnitTest {
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 		settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
 		Assert.assertEquals(settings.getAsList("ALL").get(0), "indices:*");
+		Assert.assertFalse(settings.hasValue("INTERNAL.permissions"));
 	}
 
 }

--- a/src/test/java/com/floragunn/searchguard/dlic/rest/api/RolesApiTest.java
+++ b/src/test/java/com/floragunn/searchguard/dlic/rest/api/RolesApiTest.java
@@ -60,6 +60,10 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
 		response = rh.executeGetRequest("/_searchguard/api/roles", new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
+	    // hidden role
+        response = rh.executeGetRequest("/_searchguard/api/roles/sg_internal", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+		
 		// create index
 		setupStarfleetIndex();
 
@@ -72,6 +76,7 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
 		// TODO: only one doctype allowed for ES6
 		//checkWriteAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "public", 0);
 
+		
 		// -- DELETE
 
 		rh.sendHTTPClientCertificate = true;
@@ -84,6 +89,10 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
 		response = rh.executeDeleteRequest("/_searchguard/api/roles/sg_transport_client", new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
 
+	    // hidden role
+        response = rh.executeDeleteRequest("/_searchguard/api/roles/sg_internal", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+		
 		// remove complete role mapping for sg_role_starfleet_captains
 		response = rh.executeDeleteRequest("/_searchguard/api/roles/sg_role_starfleet_captains", new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
@@ -142,6 +151,11 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
 		response = rh.executePutRequest("/_searchguard/api/roles/sg_transport_client",
 				FileHelper.loadFile("restapi/roles_captains.json"), new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+		
+        // put hidden role, must be forbidden
+        response = rh.executePutRequest("/_searchguard/api/roles/sg_internal",
+                FileHelper.loadFile("restapi/roles_captains.json"), new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());		
 		
 		// restore starfleet role
 		response = rh.executePutRequest("/_searchguard/api/roles/sg_role_starfleet",

--- a/src/test/java/com/floragunn/searchguard/dlic/rest/api/RolesMappingApiTest.java
+++ b/src/test/java/com/floragunn/searchguard/dlic/rest/api/RolesMappingApiTest.java
@@ -66,6 +66,10 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
 		response = rh.executeGetRequest("/_searchguard/api/rolesmapping", new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
+	    // GET, rolesmapping is hidden
+        response = rh.executeGetRequest("/_searchguard/api/rolesmapping/sg_role_internal", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+		
 		// create index
 		setupStarfleetIndex();
 
@@ -89,6 +93,10 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
 		response = rh.executeDeleteRequest("/_searchguard/api/rolesmapping/sg_role_starfleet_library", new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
 
+        // hidden role
+        response = rh.executeDeleteRequest("/_searchguard/api/rolesmapping/sg_role_internal", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());		
+		
 		// remove complete role mapping for sg_role_starfleet_captains
 		response = rh.executeDeleteRequest("/_searchguard/api/rolesmapping/sg_role_starfleet_captains", new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
@@ -170,6 +178,10 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
 				FileHelper.loadFile("restapi/rolesmapping_all_access.json"), new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
 
+        // hidden role
+        response = rh.executePutRequest("/_searchguard/api/rolesmapping/sg_role_internal", 
+                FileHelper.loadFile("restapi/rolesmapping_all_access.json"), new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode()); 		
 		
 		response = rh.executePutRequest("/_searchguard/api/rolesmapping/sg_role_starfleet_captains",
 				FileHelper.loadFile("restapi/rolesmapping_all_access.json"), new Header[0]);

--- a/src/test/java/com/floragunn/searchguard/dlic/rest/api/UserApiTest.java
+++ b/src/test/java/com/floragunn/searchguard/dlic/rest/api/UserApiTest.java
@@ -132,6 +132,10 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 		response = rh.executeDeleteRequest("/_searchguard/api/user/sarek", new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
 
+        // try remove hidden user
+        response = rh.executeDeleteRequest("/_searchguard/api/user/q", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());		
+		
 		// now really remove user
 		deleteUser("nagilum");
 

--- a/src/test/resources/restapi/sg_action_groups.yml
+++ b/src/test/resources/restapi/sg_action_groups.yml
@@ -41,6 +41,11 @@ GET:
   permissions:
     - "indices:data/read/get*"
     - "indices:data/read/mget*"
+INTERNAL:
+  hidden: true
+  permissions:
+    - "indices:data/read/get*"
+    - "indices:data/read/mget*"  
 
 # CLUSTER
 CLUSTER_ALL:

--- a/src/test/resources/restapi/sg_internal_users.yml
+++ b/src/test/resources/restapi/sg_internal_users.yml
@@ -12,4 +12,7 @@ worf:
   roles:
     - klingon
 test:
-  hash: $2a$12$1HqHxm3QTfzwkse7vwzhFOV4gDv787cZ8BwmCwNEyJhn0CZoo8VVu        
+  hash: $2a$12$1HqHxm3QTfzwkse7vwzhFOV4gDv787cZ8BwmCwNEyJhn0CZoo8VVu
+q:
+  hidden: true
+  hash: $2a$12$Ioo1uXmH.Nq/lS5dUVBEsePSmZ5pSIpVO/xKHaquU/Jvq97I7nAgG

--- a/src/test/resources/restapi/sg_roles.yml
+++ b/src/test/resources/restapi/sg_roles.yml
@@ -113,6 +113,15 @@ sg_transport_client:
       #uncomment the following for sniffing
       #- cluster:monitor/state
 
+sg_internal:
+  hidden: true
+  cluster:
+    - CLUSTER_ALL
+  indices:
+    '*':
+      '*':
+        - ALL
+
 sg_kibana4:
   cluster: 
       - cluster:monitor/nodes/info

--- a/src/test/resources/restapi/sg_roles_mapping.yml
+++ b/src/test/resources/restapi/sg_roles_mapping.yml
@@ -18,6 +18,12 @@ sg_role_starfleet_library:
     - 'starfleet*'
     - ambassador
 
+sg_role_internal:
+  hidden: true
+  backendroles:
+    - 'starfleet*'
+    - ambassador
+
 sg_role_vulcans:
   backendroles:
     - vulcangov


### PR DESCRIPTION
Support for HTTP PATCH for REST API.

Implementation was remarkably straight-forward.

Note: This also includes the hidden resource commits, as this depends on them.